### PR TITLE
fix: update deploy to use first class gh actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,26 +1,55 @@
-name: Deploy To Github Page
+name: Deploy to GitHub Pages
 
 on:
     workflow_dispatch:
     push:
         tags: v*
 
+permissions:
+    contents: read
+    pages: write
+    id-token: write
+
+concurrency:
+    group: "pages"
+    cancel-in-progress: false
+
 jobs:
-    deploy-prod:
+    build:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@master
-              with:
-                  persist-credentials: false
-            - uses: actions/setup-node@master
+            - name: Checkout
+              uses: actions/checkout@v4
+            
+            - name: Setup Node
+              uses: actions/setup-node@v4
               with:
                   node-version: '12'
-            - run: npm install
-            - run: npm run build
-            - name: Deploy to GitHub Pages
-              uses: peaceiris/actions-gh-pages@v3
+            
+            - name: Install dependencies
+              run: npm install
+            
+            - name: Build
+              run: npm run build
+            
+            - name: Setup Pages
+              uses: actions/configure-pages@v5
+            
+            - name: Create CNAME file
+              run: echo "planning-poker.appsample.com" > ./build/CNAME
+            
+            - name: Upload artifact
+              uses: actions/upload-pages-artifact@v3
               with:
-                  github_token: ${{ secrets.CICD_TOKEN }}
-                  publish_dir: ./build
-                  publish_branch: gh-pages
-                  cname: planning-poker.appsample.com
+                  path: ./build
+
+    deploy:
+        environment:
+            name: github-pages
+            url: ${{ steps.deployment.outputs.page_url }}
+        runs-on: ubuntu-latest
+        needs: build
+        steps:
+            - name: Deploy to GitHub Pages
+              id: deployment
+              uses: actions/deploy-pages@v4


### PR DESCRIPTION
This PR updates GitHub Pages deployment to use GitHub's official actions, replacing the deprecated third-party peaceiris action.

https://github.com/actions/deploy-pages

### Changes

- Uses official actions/configure-pages@v5, actions/upload-pages-artifact@v3, actions/deploy-pages@v4
- Removes CICD_TOKEN dependency
- Separates build/deploy jobs

### Required Setup

- Change Pages source to "GitHub Actions" in Settings > Pages
- Delete old CICD_TOKEN secret

### Benefits

- Official support
- Better security (OIDC tokens)
- Future-proof