### PR TITLE
fixed removing self bug

### DIFF
--- a/src/components/Player/Player.js
+++ b/src/components/Player/Player.js
@@ -1,8 +1,9 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { CSSTransition } from 'react-transition-group';
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 
+import { setRemovedSelf } from 'store/session';
 import Modal from 'components/Utilities/Modal';
 import db from 'libraries/database';
 import { ucfirst } from 'libraries/stringHelper';
@@ -24,6 +25,7 @@ function Player({ name, player, showVotes, mode = 'points' }) {
     }
 
     const [removeModal, setRemoveModal] = useState(false);
+    const dispatch = useDispatch();
     const user = useSelector((state) => state.user);
     const cheated = showVotes && player.cheated && player.connected;
 
@@ -91,7 +93,12 @@ function Player({ name, player, showVotes, mode = 'points' }) {
                     body={<i>* Players can join as observers if they don't intend to vote.</i>}
                     setVisibility={setRemoveModal}
                     confirmText="Remove"
-                    confirmHandler={() => db.deletePlayer(name)}
+                    confirmHandler={() => {
+                        db.deletePlayer(name);
+                        if (name === user.userName) {
+                            dispatch(setRemovedSelf(true));
+                        }
+                    }}
                 />
             )}
         </div>

--- a/src/components/Room/Room.js
+++ b/src/components/Room/Room.js
@@ -2,7 +2,7 @@ import React, { Profiler, useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
 import { useSelector, useDispatch } from 'react-redux';
 
-import { setSessionName, setSessionData, setConfetti } from 'store/session';
+import { setSessionName, setSessionData, setConfetti, setRemovedSelf } from 'store/session';
 import { ucfirst, trimName } from 'libraries/stringHelper';
 import { getAvgPoint } from 'libraries/mathHelper';
 import { allPlayersVoted, getUserPoint, isConsistent } from 'libraries/playerHelper';
@@ -24,11 +24,12 @@ function Room({ match, location, mode = 'points' }) {
     const observer = location.search.indexOf('?observer') === 0;
     // get data from store
     const sessionData = useSelector((state) => state.session.data) || {};
+    const removedSelf = useSelector((state) => state.session.removedSelf);
     const playersFromStore = sessionData.players ?? {};
     const userName = useSelector((state) => (observer ? '' : state.user.userName));
-    // Ensure current user is always in the list so their name persists when switching poker/tshirt
+    // Ensure current user is in the list when not removed (so name persists when switching poker/tshirt)
     const players =
-        userName && !observer && !playersFromStore[userName]
+        userName && !observer && !removedSelf && !playersFromStore[userName]
             ? { ...playersFromStore, [userName]: { point: mode === 'tshirt' ? '' : 0, connected: true, cheated: false } }
             : playersFromStore;
     // parse data
@@ -55,6 +56,7 @@ function Room({ match, location, mode = 'points' }) {
             });
             // clean up
             return () => {
+                dispatch(setRemovedSelf(false));
                 db.detachListener();
                 db.offline();
             };

--- a/src/components/Room/Room.js
+++ b/src/components/Room/Room.js
@@ -27,9 +27,10 @@ function Room({ match, location, mode = 'points' }) {
     const removedSelf = useSelector((state) => state.session.removedSelf);
     const playersFromStore = sessionData.players ?? {};
     const userName = useSelector((state) => (observer ? '' : state.user.userName));
-    // Ensure current user is in the list when not removed (so name persists when switching poker/tshirt)
+    // Add current user only when store is empty (e.g. just switched poker/tshirt), not when removed by someone else
+    const storeEmpty = Object.keys(playersFromStore).length === 0;
     const players =
-        userName && !observer && !removedSelf && !playersFromStore[userName]
+        userName && !observer && !removedSelf && !playersFromStore[userName] && storeEmpty
             ? { ...playersFromStore, [userName]: { point: mode === 'tshirt' ? '' : 0, connected: true, cheated: false } }
             : playersFromStore;
     // parse data

--- a/src/store/session.js
+++ b/src/store/session.js
@@ -9,6 +9,7 @@ export const sessionSlice = createSlice({
     initialState: {
         sessionName: localStorage.getItem(KEY_SESSION_NAME) || '',
         confetti: false,
+        removedSelf: false, // true when current user removed themselves (stay as observer, hide own card)
         data: {
             showPoints: 0,
             players: {
@@ -37,9 +38,12 @@ export const sessionSlice = createSlice({
         setConfetti: (state, action) => {
             state.confetti = !!action.payload;
         },
+        setRemovedSelf: (state, action) => {
+            state.removedSelf = !!action.payload;
+        },
     },
 });
 
-export const { setSessionName, setSessionData, setConfetti } = sessionSlice.actions;
+export const { setSessionName, setSessionData, setConfetti, setRemovedSelf } = sessionSlice.actions;
 
 export default sessionSlice.reducer;


### PR DESCRIPTION
When removing self from a game, it would remove you from other sessions properly but on your own window it would show you as still active. fixed that so that you're not visible but still able to re-join with either a refresh of page or clicking one of the cards. 