### PR TITLE
feat: add adjustable t-shirt sizing legend

### DIFF
--- a/src/components/Player/Player.js
+++ b/src/components/Player/Player.js
@@ -85,7 +85,7 @@ function Player({ name, player, showVotes, mode = 'points' }) {
                 </div>
             </div>
             <div className={`${user.userName === name ? 'text-warning' : ''} __player__name`}>
-                {user.userName === name && user.displayName ? user.displayName : ucfirst(name)}
+                {user.userName === name && user.displayName ? ucfirst(user.displayName) : ucfirst(name)}
             </div>
             {removeModal && (
                 <Modal

--- a/src/components/Room/Room.js
+++ b/src/components/Room/Room.js
@@ -11,6 +11,7 @@ import reporter from 'libraries/reporter';
 import Table from 'components/Table/Table';
 import Cards from 'components/Cards/Cards';
 import TshirtCards from 'components/Cards/TshirtCards';
+import TshirtLegend from 'components/TshirtLegend/TshirtLegend';
 import Setting from 'components/Setting/Setting';
 
 import './Room.scss';
@@ -26,6 +27,7 @@ function Room({ match, location, mode = 'points' }) {
     const sessionData = useSelector((state) => state.session.data) || {};
     const removedSelf = useSelector((state) => state.session.removedSelf);
     const playersFromStore = sessionData.players ?? {};
+    const tshirtLegend = sessionData.tshirtLegend;
     const userName = useSelector((state) => (observer ? '' : state.user.userName));
     // Add current user only when store is empty (e.g. just switched poker/tshirt), not when removed by someone else
     const storeEmpty = Object.keys(playersFromStore).length === 0;
@@ -113,6 +115,8 @@ function Room({ match, location, mode = 'points' }) {
                     </div>
                 </div>
             )}
+
+            {mode === 'tshirt' && <TshirtLegend legend={tshirtLegend} />}
 
             <Setting mode={mode} />
         </div>

--- a/src/components/TshirtLegend/TshirtLegend.js
+++ b/src/components/TshirtLegend/TshirtLegend.js
@@ -8,12 +8,12 @@ const DEFAULT_LEGEND = {
     title: 'T-Shirt Sizing Legend',
     subtext: "time estimates based on one engineer's full time dedicated to the task",
     values: {
-        XS: '1 week',
-        S: '2 weeks',
-        M: '4 weeks',
-        L: '8 weeks',
-        XL: '16 weeks',
-        XXL: '32 weeks',
+        XS: '1 wk',
+        S: '2 wks',
+        M: '4 wks',
+        L: '8 wks',
+        XL: '16 wks',
+        XXL: '32 wks',
     },
 };
 

--- a/src/components/TshirtLegend/TshirtLegend.js
+++ b/src/components/TshirtLegend/TshirtLegend.js
@@ -8,12 +8,12 @@ const DEFAULT_LEGEND = {
     title: 'T-Shirt Sizing Legend',
     subtext: "time estimates based on one engineer's full time dedicated to the task",
     values: {
-        XS: '0.5 weeks',
-        S: '1 week',
-        M: '2 weeks',
-        L: '4 weeks',
-        XL: '8 weeks',
-        XXL: '16 weeks',
+        XS: '1 week',
+        S: '2 weeks',
+        M: '4 weeks',
+        L: '8 weeks',
+        XL: '16 weeks',
+        XXL: '32 weeks',
     },
 };
 
@@ -169,14 +169,26 @@ function TshirtLegend({ legend }) {
                     </button>
                 </div>
                 <div className="__tshirt-legend__values">
-                    {Object.entries(currentLegend.values).map(([size, value]) => (
-                        <div key={size} className="__tshirt-legend__item">
-                            <span className={`__tshirt-legend__badge __tshirt-legend__badge--${size.toLowerCase()}`}>
-                                {size}
-                            </span>
-                            <span className="__tshirt-legend__value">{value}</span>
-                        </div>
-                    ))}
+                    <div className="__tshirt-legend__column">
+                        {['XS', 'S', 'M'].map((size) => (
+                            <div key={size} className="__tshirt-legend__item">
+                                <span className={`__tshirt-legend__badge __tshirt-legend__badge--${size.toLowerCase()}`}>
+                                    {size}
+                                </span>
+                                <span className="__tshirt-legend__value">{currentLegend.values[size]}</span>
+                            </div>
+                        ))}
+                    </div>
+                    <div className="__tshirt-legend__column">
+                        {['L', 'XL', 'XXL'].map((size) => (
+                            <div key={size} className="__tshirt-legend__item">
+                                <span className={`__tshirt-legend__badge __tshirt-legend__badge--${size.toLowerCase()}`}>
+                                    {size}
+                                </span>
+                                <span className="__tshirt-legend__value">{currentLegend.values[size]}</span>
+                            </div>
+                        ))}
+                    </div>
                 </div>
                 {currentLegend.subtext && (
                     <p className="__tshirt-legend__subtext">{currentLegend.subtext}</p>

--- a/src/components/TshirtLegend/TshirtLegend.js
+++ b/src/components/TshirtLegend/TshirtLegend.js
@@ -1,0 +1,198 @@
+import React, { Fragment, useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import PropTypes from 'prop-types';
+import db from 'libraries/database';
+import './TshirtLegend.scss';
+
+const DEFAULT_LEGEND = {
+    title: 'T-Shirt Sizing Legend',
+    subtext: "time estimates based on one engineer's full time dedicated to the task",
+    values: {
+        XS: '0.5 weeks',
+        S: '1 week',
+        M: '2 weeks',
+        L: '4 weeks',
+        XL: '8 weeks',
+        XXL: '16 weeks',
+    },
+};
+
+const mount = document.getElementById('modal');
+
+function TshirtLegend({ legend }) {
+    const [showModal, setShowModal] = useState(false);
+    const [editedLegend, setEditedLegend] = useState(DEFAULT_LEGEND);
+    const containerRef = useRef(null);
+    const modalRef = useRef(null);
+
+    if (!containerRef.current) {
+        containerRef.current = document.createElement('div');
+    }
+    const el = containerRef.current;
+
+    const currentLegend = legend || DEFAULT_LEGEND;
+
+    useEffect(() => {
+        if (showModal && mount) {
+            mount.appendChild(el);
+            window.setTimeout(() => {
+                if (modalRef.current) modalRef.current.className += ' show';
+            }, 100);
+            return () => {
+                if (mount.contains(el)) {
+                    mount.removeChild(el);
+                }
+            };
+        }
+    }, [showModal, el]);
+
+    const handleEdit = () => {
+        setEditedLegend(currentLegend);
+        setShowModal(true);
+    };
+
+    const handleSave = () => {
+        db.setTshirtLegend(editedLegend);
+        setShowModal(false);
+    };
+
+    const handleCancel = () => {
+        setShowModal(false);
+    };
+
+    const handleValueChange = (size, value) => {
+        setEditedLegend({
+            ...editedLegend,
+            values: {
+                ...editedLegend.values,
+                [size]: value,
+            },
+        });
+    };
+
+    const modalContent = showModal
+        ? createPortal(
+              <Fragment>
+                  <div className="modal-backdrop fade show"></div>
+                  <div ref={modalRef} className="modal d-block fade">
+                      <div className="modal-dialog">
+                          <div className="modal-content">
+                              <div className="modal-header">
+                                  <h5 className="modal-title">Edit T-Shirt Sizing Legend</h5>
+                                  <button
+                                      type="button"
+                                      className="btn-close"
+                                      aria-label="Close"
+                                      onClick={handleCancel}
+                                  ></button>
+                              </div>
+                              <div className="modal-body">
+                                  <div className="mb-3">
+                                      <label htmlFor="legend-title" className="form-label">
+                                          Title
+                                      </label>
+                                      <input
+                                          type="text"
+                                          className="form-control"
+                                          id="legend-title"
+                                          value={editedLegend.title}
+                                          onChange={(e) => setEditedLegend({ ...editedLegend, title: e.target.value })}
+                                      />
+                                  </div>
+
+                                  <div className="mb-3">
+                                      <label className="form-label">Size Values</label>
+                                      {Object.entries(editedLegend.values).map(([size, value]) => (
+                                          <div key={size} className="input-group mb-2">
+                                              <span className="input-group-text" style={{ minWidth: '60px' }}>
+                                                  {size}
+                                              </span>
+                                              <input
+                                                  type="text"
+                                                  className="form-control"
+                                                  value={value}
+                                                  onChange={(e) => handleValueChange(size, e.target.value)}
+                                                  placeholder="e.g., 1 week"
+                                              />
+                                          </div>
+                                      ))}
+                                  </div>
+
+                                  <div className="mb-3">
+                                      <label htmlFor="legend-subtext" className="form-label">
+                                          Subtext
+                                      </label>
+                                      <textarea
+                                          className="form-control"
+                                          id="legend-subtext"
+                                          rows="2"
+                                          value={editedLegend.subtext}
+                                          onChange={(e) => setEditedLegend({ ...editedLegend, subtext: e.target.value })}
+                                      />
+                                  </div>
+                              </div>
+                              <div className="modal-footer">
+                                  <button className="btn btn-secondary" onClick={handleCancel}>
+                                      Cancel
+                                  </button>
+                                  <button className="btn btn-primary" onClick={handleSave}>
+                                      Save Legend
+                                  </button>
+                              </div>
+                          </div>
+                      </div>
+                  </div>
+              </Fragment>,
+              el
+          )
+        : null;
+
+    return (
+        <>
+            <div className="__tshirt-legend">
+                <div className="__tshirt-legend__header">
+                    <h5 className="__tshirt-legend__title">{currentLegend.title}</h5>
+                    <button
+                        className="btn btn-sm btn-outline-secondary __tshirt-legend__edit-btn"
+                        onClick={handleEdit}
+                        aria-label="Edit legend"
+                    >
+                        <svg
+                            xmlns="http://www.w3.org/2000/svg"
+                            width="16"
+                            height="16"
+                            fill="currentColor"
+                            viewBox="0 0 16 16"
+                        >
+                            <path d="M12.146.146a.5.5 0 0 1 .708 0l3 3a.5.5 0 0 1 0 .708l-10 10a.5.5 0 0 1-.168.11l-5 2a.5.5 0 0 1-.65-.65l2-5a.5.5 0 0 1 .11-.168l10-10zM11.207 2.5 13.5 4.793 14.793 3.5 12.5 1.207 11.207 2.5zm1.586 3L10.5 3.207 4 9.707V10h.5a.5.5 0 0 1 .5.5v.5h.5a.5.5 0 0 1 .5.5v.5h.293l6.5-6.5zm-9.761 5.175-.106.106-1.528 3.821 3.821-1.528.106-.106A.5.5 0 0 1 5 12.5V12h-.5a.5.5 0 0 1-.5-.5V11h-.5a.5.5 0 0 1-.468-.325z" />
+                        </svg>
+                    </button>
+                </div>
+                <div className="__tshirt-legend__values">
+                    {Object.entries(currentLegend.values).map(([size, value]) => (
+                        <div key={size} className="__tshirt-legend__item">
+                            <span className={`__tshirt-legend__badge __tshirt-legend__badge--${size.toLowerCase()}`}>
+                                {size}
+                            </span>
+                            <span className="__tshirt-legend__value">{value}</span>
+                        </div>
+                    ))}
+                </div>
+                {currentLegend.subtext && (
+                    <p className="__tshirt-legend__subtext">{currentLegend.subtext}</p>
+                )}
+            </div>
+            {modalContent}
+        </>
+    );
+}
+
+TshirtLegend.propTypes = {
+    legend: PropTypes.shape({
+        title: PropTypes.string,
+        subtext: PropTypes.string,
+        values: PropTypes.objectOf(PropTypes.string),
+    }),
+};
+
+export default React.memo(TshirtLegend);

--- a/src/components/TshirtLegend/TshirtLegend.scss
+++ b/src/components/TshirtLegend/TshirtLegend.scss
@@ -9,9 +9,10 @@
 
     &__header {
         display: flex;
-        justify-content: space-between;
+        justify-content: center;
         align-items: center;
         margin-bottom: 12px;
+        position: relative;
     }
 
     &__title {
@@ -19,12 +20,15 @@
         font-size: 1.1rem;
         font-weight: 600;
         color: #fff;
+        text-align: center;
     }
 
     &__edit-btn {
         padding: 4px 8px;
         border-color: rgba(255, 255, 255, 0.3);
         color: rgba(255, 255, 255, 0.8);
+        position: absolute;
+        right: 0;
 
         &:hover {
             background: rgba(255, 255, 255, 0.1);

--- a/src/components/TshirtLegend/TshirtLegend.scss
+++ b/src/components/TshirtLegend/TshirtLegend.scss
@@ -1,0 +1,132 @@
+.__tshirt-legend {
+    background: rgba(255, 255, 255, 0.1);
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    border-radius: 8px;
+    padding: 16px;
+    margin: 20px auto;
+    max-width: 600px;
+    color: #fff;
+
+    &__header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 12px;
+    }
+
+    &__title {
+        margin: 0;
+        font-size: 1.1rem;
+        font-weight: 600;
+        color: #fff;
+    }
+
+    &__edit-btn {
+        padding: 4px 8px;
+        border-color: rgba(255, 255, 255, 0.3);
+        color: rgba(255, 255, 255, 0.8);
+
+        &:hover {
+            background: rgba(255, 255, 255, 0.1);
+            border-color: rgba(255, 255, 255, 0.5);
+            color: #fff;
+        }
+    }
+
+    &__values {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+        gap: 8px;
+        margin-bottom: 12px;
+    }
+
+    &__item {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 6px;
+        background: rgba(0, 0, 0, 0.2);
+        border-radius: 4px;
+    }
+
+    &__badge {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-width: 40px;
+        padding: 4px 8px;
+        font-size: 0.75rem;
+        font-weight: 600;
+        border-radius: 4px;
+        color: #fff;
+
+        &--xs {
+            background: rgba(34, 197, 94, 0.9);
+        }
+        &--s {
+            background: rgba(101, 163, 13, 0.9);
+        }
+        &--m {
+            background: rgba(202, 138, 4, 0.9);
+        }
+        &--l {
+            background: rgba(234, 88, 12, 0.9);
+        }
+        &--xl {
+            background: rgba(220, 38, 38, 0.9);
+        }
+        &--xxl {
+            background: rgba(153, 27, 27, 0.9);
+        }
+    }
+
+    &__value {
+        font-size: 0.9rem;
+        color: rgba(255, 255, 255, 0.9);
+    }
+
+    &__subtext {
+        margin: 0;
+        font-size: 0.85rem;
+        color: rgba(255, 255, 255, 0.7);
+        font-style: italic;
+        text-align: center;
+        border-top: 1px solid rgba(255, 255, 255, 0.1);
+        padding-top: 12px;
+    }
+
+    .modal-dialog {
+        max-width: 500px;
+    }
+
+    .form-label {
+        font-weight: 600;
+        margin-bottom: 8px;
+    }
+
+    .input-group-text {
+        font-weight: 600;
+        background: rgba(0, 0, 0, 0.05);
+    }
+}
+
+// Responsive adjustments
+@media (max-width: 768px) {
+    .__tshirt-legend {
+        padding: 12px;
+        margin: 16px auto;
+
+        &__values {
+            grid-template-columns: repeat(2, 1fr);
+        }
+
+        &__title {
+            font-size: 1rem;
+        }
+
+        .modal-dialog {
+            max-width: 95%;
+            margin: 1rem auto;
+        }
+    }
+}

--- a/src/components/TshirtLegend/TshirtLegend.scss
+++ b/src/components/TshirtLegend/TshirtLegend.scss
@@ -38,6 +38,9 @@
         grid-template-columns: 1fr 1fr;
         gap: 12px;
         margin-bottom: 12px;
+        max-width: 400px;
+        margin-left: auto;
+        margin-right: auto;
     }
 
     &__column {

--- a/src/components/TshirtLegend/TshirtLegend.scss
+++ b/src/components/TshirtLegend/TshirtLegend.scss
@@ -35,9 +35,15 @@
 
     &__values {
         display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-        gap: 8px;
+        grid-template-columns: 1fr 1fr;
+        gap: 12px;
         margin-bottom: 12px;
+    }
+
+    &__column {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
     }
 
     &__item {
@@ -117,11 +123,27 @@
         margin: 16px auto;
 
         &__values {
-            grid-template-columns: repeat(2, 1fr);
+            grid-template-columns: 1fr 1fr;
+            gap: 8px;
         }
 
         &__title {
             font-size: 1rem;
+        }
+
+        &__item {
+            padding: 4px;
+            font-size: 0.85rem;
+        }
+
+        &__badge {
+            min-width: 32px;
+            padding: 3px 6px;
+            font-size: 0.7rem;
+        }
+
+        &__value {
+            font-size: 0.8rem;
         }
 
         .modal-dialog {

--- a/src/libraries/database.js
+++ b/src/libraries/database.js
@@ -85,6 +85,15 @@ class FirebaseClient {
         }
     }
 
+    setTshirtLegend(legend) {
+        if (this.sessionType === 'tshirt') {
+            this.db
+                .ref(this.sessionName + '/tshirtLegend')
+                .set(legend)
+                .catch(this.errorHandler);
+        }
+    }
+
     renameUser(newName) {
         if (!this.sessionName || !this.userName || !newName || this.userName === newName) return;
         const newNameTrimmed = (newName || '').trim().toLowerCase();


### PR DESCRIPTION
## Summary

- Added customizable legend component for t-shirt sizing sessions
- Teams can define their own time estimates for each size (XS through XXL)
- Legend includes editable title, values, and subtext
- Settings are session-specific and stored in Firebase
- Only displayed in t-shirt sizing mode
- Fixed display name capitalization consistency

## Features

- **Editable Legend**: Click the edit button to customize title, size values, and subtext
- **Default Values**: 
  - XS = 1 wk
  - S = 2 wks
  - M = 4 wks
  - L = 8 wks
  - XL = 16 wks
  - XXL = 32 wks
- **Default Subtext**: "time estimates based on one engineer's full time dedicated to the task"
- **Two-Column Layout**: Left column (XS, S, M) and right column (L, XL, XXL) for better readability
- **Centered Title**: Legend title is centered with edit button positioned on the right
- **Color-Coded Badges**: Matches the color scheme of the t-shirt cards (green → yellow → red gradient)
- **Responsive Design**: Centered layout that adapts to mobile and desktop screens
- **Session Persistence**: Each team's legend settings are stored independently in their session

## Additional Fixes

- **Display Name Capitalization**: Applied `ucfirst()` to display names for consistency with regular names

## Implementation Details

- New `TshirtLegend` component with built-in modal for editing
- Database method `setTshirtLegend()` added to save legend to Firebase
- Integrated into `Room` component, displayed below cards in t-shirt mode
- Legend data stored under `tshirt_${sessionName}/tshirtLegend` in Firebase

## Test plan

- [x] Navigate to a t-shirt sizing session
- [x] Verify legend displays with default values in two-column centered layout
- [x] Click edit button and customize title, values, and subtext
- [x] Save changes and verify they persist on page refresh
- [x] Verify legend settings are unique per session (don't cross between rooms)
- [x] Test responsive layout on mobile and desktop
- [x] Verify legend only appears in t-shirt mode, not in regular poker mode
- [x] Verify display names are properly capitalized

🤖 Generated with [Claude Code](https://claude.com/claude-code)