### PR TITLE
Fix auto-rejoin bug and add manual rejoin button

### DIFF
--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -3,6 +3,7 @@ import { Link, useLocation, useHistory } from 'react-router-dom';
 import { useSelector, useDispatch } from 'react-redux';
 
 import { setUserName } from 'store/user';
+import { setRemovedSelf } from 'store/session';
 import { ucfirst, trimName } from 'libraries/stringHelper';
 import db from 'libraries/database';
 import Modal from 'components/Utilities/Modal';
@@ -20,6 +21,7 @@ function Header() {
     const dispatch = useDispatch();
     const userName = useSelector((state) => state.user.userName);
     const displayName = useSelector((state) => state.user.displayName);
+    const removedSelf = useSelector((state) => state.session.removedSelf);
     const location = useLocation();
     const history = useHistory();
     const pathname = location.pathname || '';
@@ -27,6 +29,7 @@ function Header() {
     const inRoom = sessionName && pathname !== '/';
     const onPoker = inRoom && (pathname.startsWith('/poker/') || (!pathname.startsWith('/tshirt/') && !pathname.startsWith('/poker/')));
     const onTshirt = inRoom && pathname.startsWith('/tshirt/');
+    const observer = location.search.indexOf('?observer') === 0;
 
     const [showNameModal, setShowNameModal] = useState(false);
     const [nameInput, setNameInput] = useState('');
@@ -51,6 +54,11 @@ function Header() {
         if (!trimmed) return;
         dispatch(setUserName(trimmed));
         if (inRoom) db.renameUser(trimName(trimmed));
+    };
+
+    const handleRejoin = () => {
+        dispatch(setRemovedSelf(false));
+        db.rejoinSession();
     };
 
     return (
@@ -83,6 +91,16 @@ function Header() {
                     </div>
                 )}
                 <div className="navbar-text ms-auto">
+                    {inRoom && !observer && removedSelf && (
+                        <button
+                            type="button"
+                            className="btn btn-primary btn-sm me-3"
+                            onClick={handleRejoin}
+                            title="Rejoin the voting session"
+                        >
+                            Rejoin Session
+                        </button>
+                    )}
                     <img className="__header__profile" alt="profile" src="img/profile.svg" />
                     <button
                         type="button"

--- a/src/components/Room/Room.js
+++ b/src/components/Room/Room.js
@@ -68,6 +68,12 @@ function Room({ match, location, mode = 'points' }) {
         }
     }, [dispatch, history, sessionName, userName, observer, mode]);
 
+    useEffect(() => {
+        if (removedSelf) {
+            db.markAsRemoved();
+        }
+    }, [removedSelf]);
+
     return (
         <div className="__room" style={{ backgroundImage: `url(${process.env.PUBLIC_URL}/img/poker-desk.jpg)` }}>
             <div className="d-flex align-items-center justify-content-center __room__session">

--- a/src/libraries/database.js
+++ b/src/libraries/database.js
@@ -8,6 +8,7 @@ class FirebaseClient {
         this.db = firebase.database();
         this.sessionName = '';
         this.userName = '';
+        this.isRemovedFromSession = false;
         reporter.log('new FirebaseClient()');
     }
 
@@ -24,7 +25,7 @@ class FirebaseClient {
             // track online status
             const connectedRef = this.db.ref('.info/connected');
             connectedRef.on('value', (snap) => {
-                if (snap.val() === true) {
+                if (snap.val() === true && !this.isRemovedFromSession) {
                     const con = this.db.ref(this.sessionName + '/players/' + this.userName + '/connected');
                     con.onDisconnect().remove();
                     con.set(true);
@@ -94,6 +95,33 @@ class FirebaseClient {
         }
     }
 
+    markAsRemoved() {
+        this.isRemovedFromSession = true;
+        // Turn off connection listener to prevent auto-rejoin
+        this.db.ref('.info/connected').off();
+    }
+
+    rejoinSession() {
+        if (!this.userName || !this.sessionName) return;
+
+        // Reset removed flag
+        this.isRemovedFromSession = false;
+
+        // Re-add user with unvoted value
+        const unvotedValue = this.sessionType === 'tshirt' ? '' : 0;
+        this.setPoint(unvotedValue);
+
+        // Re-establish connection tracking
+        const connectedRef = this.db.ref('.info/connected');
+        connectedRef.on('value', (snap) => {
+            if (snap.val() === true && !this.isRemovedFromSession) {
+                const con = this.db.ref(this.sessionName + '/players/' + this.userName + '/connected');
+                con.onDisconnect().remove();
+                con.set(true);
+            }
+        });
+    }
+
     renameUser(newName) {
         if (!this.sessionName || !this.userName || !newName || this.userName === newName) return;
         const newNameTrimmed = (newName || '').trim().toLowerCase();
@@ -117,7 +145,7 @@ class FirebaseClient {
                         this.userName = newNameTrimmed;
                         const connectedRef = this.db.ref('.info/connected');
                         connectedRef.on('value', (snap) => {
-                            if (snap.val() === true) {
+                            if (snap.val() === true && !this.isRemovedFromSession) {
                                 const con = this.db.ref(this.sessionName + '/players/' + this.userName + '/connected');
                                 con.onDisconnect().remove();
                                 con.set(true);


### PR DESCRIPTION
## Summary
- Fixes bug where users were automatically re-added to sessions after removal when browser reconnected to Firebase
- Adds "Rejoin Session" button in header for manual rejoin
- Users now stay removed until manually rejoining or refreshing page

## Changes
- **database.js**: Added `isRemovedFromSession` flag, `markAsRemoved()` and `rejoinSession()` methods, and conditional checks in connection listeners to prevent auto-rejoin
- **Room.js**: Added useEffect to notify database when user is removed (`removedSelf` changes to true)
- **Header.js**: Added "Rejoin Session" button that appears when user is removed from session (only shown when in room, not observer, and `removedSelf` is true)

## Behavior
- **Before**: User removed → Firebase reconnects → User auto-rejoins (bug)
- **After**: User removed → Firebase reconnects → User stays removed (fixed)
- **Page refresh**: Still allows auto-rejoin (as intended per requirements)

## Test Plan
- [ ] Remove yourself from a session (right-click your card)
- [ ] Simulate network disconnect/reconnect (Chrome DevTools offline mode)
- [ ] Verify: Card should NOT reappear (auto-rejoin bug is fixed)
- [ ] Verify: "Rejoin Session" button appears in header
- [ ] Click "Rejoin Session" button
- [ ] Verify: Card reappears and you can vote again
- [ ] Remove yourself and refresh page
- [ ] Verify: You auto-rejoin (expected behavior)
- [ ] Remove yourself in Poker mode, switch to T-shirt mode
- [ ] Verify: You appear in T-shirt mode (expected behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)